### PR TITLE
Fixed bug that allowed duplicate movies to be added to watchlist

### DIFF
--- a/ProjectSourceCode/src/index.js
+++ b/ProjectSourceCode/src/index.js
@@ -1375,19 +1375,25 @@ app.get('/image/:identifier', async (req, res) => {
 app.post('/add-to-watchlist', async (req, res) => {
   const userId = req.session.user?.id;
   const { imdbID, title, picture, description } = req.body;
+  const alreadyAdded = await checkWatchlist(userId, title);
 
-  try {
-    console.log('In add-to-watchlist with picture:', picture);
-    const imageUrl = await uploadPoster(picture, imdbID);
-
-    await db.query(
-      'INSERT INTO watchlist (user_id, title, poster_picture, description) VALUES ($1, $2, $3, $4)',
-      [userId, title, imageUrl, description]
-    );
-
-    res.json({ success: true });
-  } catch (err) {
-    res.status(500).json({ success: false, error: 'Failed to add movie to Watchlist' });
+  if(!alreadyAdded){
+    try {
+      console.log('In add-to-watchlist with picture:', picture);
+      const imageUrl = await uploadPoster(picture, imdbID);
+    
+        await db.query(
+          'INSERT INTO watchlist (user_id, title, poster_picture, description) VALUES ($1, $2, $3, $4)',
+          [userId, title, imageUrl, description]
+        );
+        res.json({ success: true });
+    
+    } catch (err) {
+      res.status(500).json({ success: false, error: 'Failed to add movie to Watchlist' });
+    }
+  }
+  else{
+    res.status(500).json({ success: false, error: 'Movie already in watchlist' });
   }
 });
 
@@ -1408,6 +1414,19 @@ app.post('/remove-from-watchlist', async (req, res) => {
     res.render('pages/profile', { layout: 'main', error: true, message: 'Failed to remove movie from watchlist.' });
   });
 });
+
+async function checkWatchlist(userId, title){
+  const userIdString = String(userId);
+  try{
+    const inWatchlist = await db.oneOrNone('SELECT EXISTS( SELECT 1 FROM watchlist WHERE user_id = $1 AND title = $2 )', [userIdString, title]);
+    console.log('Checking watchlist and got: ', inWatchlist)
+    return inWatchlist && inWatchlist.exists;
+  }
+  catch{
+    console.error('Error finding movie in watchlist', error);
+    throw error;
+  }
+}
 
 
 // *****************************************************
@@ -1689,6 +1708,7 @@ app.get('/messaging', async (req, res) => {
 });
 
 const multer = require('multer');
+const { error } = require('console');
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 2 * 1024 * 1024 }, // 2 MB limit


### PR DESCRIPTION
Fixed the bug in which a user could go to the explorer page, add a movie to their watchlist, reload the page/movie, and add the same movie to their watchlist again. Now only 1 movie with the same exact title can be present in the watchlist.